### PR TITLE
Add progress callback and CloudScraper WAF fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,29 @@ sqldetector https://example.com/products --trace-dir traces
 
 Trace files are stored in the specified directory and can be used for reruns or auditing.
 
+### Progress and WAF handling
+
+`pipeline.run` accepts an optional `progress` callback that receives completion
+percentages.  This can be used to display progress bars or estimate remaining
+time for a scan.  When the internal HTTP client detects Cloudflare-style WAF
+blocking it automatically falls back to a `cloudscraper` session to retry the
+request.
+
+### Performance features
+
+The detector ships with several tuning knobs and optimisations:
+
+1. Adaptive per-host concurrency limits
+2. Token bucket rate limiting
+3. Dynamic hedge requests to reduce tail latency
+4. Circuit breaker on repeated failures
+5. Retry budget controls for network/server errors
+6. P95-based hedging delay calculation
+7. Progress callbacks for responsive UIs
+8. `cloudscraper` fallback for WAF evasion
+9. Compact JSON tracing to minimise I/O
+10. Reuse of HTTP/2 connections for lower overhead
+
 ## Architecture
 
 ```

--- a/sqldetector/planner/pipeline.py
+++ b/sqldetector/planner/pipeline.py
@@ -2,16 +2,22 @@
 
 import asyncio
 from pathlib import Path
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 from sqldetector.core.config import Settings
+from sqldetector.core.errors import WAFBlocked
 from sqldetector.core.http_async import HttpClient
 from sqldetector.core.logging import setup_json_logging
 from sqldetector.core.state import new_run
 from sqldetector.core.trace_writer import TraceWriter
 
 
-def run(url: str, dry_run: bool = False, settings: Optional[Settings] = None) -> List[dict]:
+def run(
+    url: str,
+    dry_run: bool = False,
+    settings: Optional[Settings] = None,
+    progress: Optional[Callable[[float], None]] = None,
+) -> List[dict]:
     settings = settings or Settings()
 
     state = new_run(settings.trace_dir or Path("traces"))
@@ -20,13 +26,30 @@ def run(url: str, dry_run: bool = False, settings: Optional[Settings] = None) ->
     trace = TraceWriter(state.run_id, state.trace_dir)
     trace.append_jsonl({"event": "pipeline_start", "url": url})
 
+    if progress:
+        progress(0.0)
+
     if dry_run:
+        if progress:
+            progress(100.0)
         return []
 
     async def _run() -> List[dict]:
         async with HttpClient(settings) as client:
-            resp = await client.get(url)
-            trace.append_jsonl({"event": "request", "status": resp.status_code})
-            return [{"status": resp.status_code}]
+            try:
+                resp = await client.get(url)
+                status = resp.status_code
+            except WAFBlocked:
+                if progress:
+                    progress(50.0)
+                import cloudscraper
+
+                scraper = cloudscraper.create_scraper()
+                resp = await asyncio.to_thread(scraper.get, url)
+                status = resp.status_code
+            if progress:
+                progress(100.0)
+            trace.append_jsonl({"event": "request", "status": status})
+            return [{"status": status}]
 
     return asyncio.run(_run())

--- a/tests/test_pipeline_progress.py
+++ b/tests/test_pipeline_progress.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+import httpx
+
+from sqldetector.core.config import Settings
+from sqldetector.planner import pipeline
+
+sys.path.append(str(Path(__file__).resolve().parent / "utils"))
+from mock_vuln_app import app  # noqa: E402
+
+
+def test_pipeline_progress():
+    transport = httpx.ASGITransport(app=app)
+    settings = Settings(transport=transport)
+    calls = []
+
+    def progress(pct: float) -> None:
+        calls.append(pct)
+
+    pipeline.run("http://testserver/products", settings=settings, progress=progress)
+    assert calls[0] == 0.0
+    assert calls[-1] == 100.0
+

--- a/tests/test_pipeline_waf_cloudscraper.py
+++ b/tests/test_pipeline_waf_cloudscraper.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import cloudscraper
+import httpx
+
+from sqldetector.core.config import Settings
+from sqldetector.core.errors import WAFBlocked
+from sqldetector.core.http_async import HttpClient
+from sqldetector.planner import pipeline
+
+sys.path.append(str(Path(__file__).resolve().parent / "utils"))
+from mock_vuln_app import app  # noqa: E402
+
+
+async def _blocked(*args, **kwargs):
+    raise WAFBlocked("blocked")
+
+
+def test_pipeline_falls_back_to_cloudscraper(monkeypatch):
+    transport = httpx.ASGITransport(app=app)
+    settings = Settings(transport=transport)
+
+    monkeypatch.setattr(HttpClient, "get", _blocked)
+
+    dummy = SimpleNamespace(status_code=200)
+    scraper = SimpleNamespace(get=lambda url: dummy)
+    monkeypatch.setattr(cloudscraper, "create_scraper", lambda: scraper)
+
+    result = pipeline.run("http://testserver/products", settings=settings)
+    assert result[0]["status"] == 200
+


### PR DESCRIPTION
## Summary
- support optional progress callback in pipeline
- fall back to `cloudscraper` when HTTP client encounters WAF blocks
- document performance features and add tests for new behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8a4da6ba88325a438d8bcc85cfda6