### PR TITLE
feat: add turbo preset and heavy-site autopilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,18 @@ Configuration keys introduced with this preset include:
 The fast pipeline performs an ultra-cheap keyword prefilter and maintains a
 fingerprint database to skip heavy tests for unchanged pages.
 
+### TURBO preset (high-spec)
+
+When ample resources are available the `turbo` preset enables an aggressive
+yet controlled scan:
+
+```
+sqldetector https://target --preset turbo
+```
+
+It expands connection pools, keeps hedging enabled and raises discovery and
+test limits while still honouring system-aware clamps.
+
 ## SMART mode
 
 An opinionated professional pipeline can be enabled with `--smart`.  It adds
@@ -178,6 +190,6 @@ python sqldetector_qwen.py --auto --print-plan https://target.example
 
 The selector looks at headers, response types and simple HTML heuristics
 to detect APIs, SPAs, form-heavy sites and WAF guarded targets. It then
-maps the profile to one of the presets such as `fast`, `stealth`,
-`api`, `spa`, `forms`, `crawler` or `budget-ci`.  Use `--force-preset` to
-override the decision.
+ maps the profile to one of the presets such as `fast`, `stealth`,
+ `api`, `spa`, `forms`, `crawler`, `budget-ci` or `turbo`.  Use
+ `--force-preset` to override the decision.

--- a/presets/turbo.toml
+++ b/presets/turbo.toml
@@ -1,0 +1,18 @@
+[sqldetector]
+stop_after_first_finding = false
+# Aggressive but controlled settings for high-spec environments
+max_connections = 100
+max_keepalive_connections = 50
+timeout_connect = 3.0
+timeout_read    = 6.0
+timeout_write   = 6.0
+timeout_pool    = 3.0
+hedge_enabled = true
+hedge_delay_ms = 75
+retry_budget = { total = 5, per_host = 3 }
+max_pages = 1000
+max_forms_per_page = 8
+max_tests_per_form = 5
+max_body_kb = 4096
+skip_binary_ext = ["jpg","jpeg","png","gif","webp","svg","ico","pdf","zip","gz","rar","7z","mp4","mp3","woff","woff2"]
+use_llm = "auto"

--- a/sqldetector/autopilot/policy.py
+++ b/sqldetector/autopilot/policy.py
@@ -11,6 +11,7 @@ PRESET_MAP = {
     "static": "fast",
     "admin": "stealth",
     "ecom": "crawler",
+    "heavy-site": "turbo",
 }
 
 

--- a/sqldetector/autopilot/selector.py
+++ b/sqldetector/autopilot/selector.py
@@ -121,6 +121,8 @@ def classify_target(seed_url: str, client: Any, sysinfo: Dict[str, Any]) -> Dict
         profile["kind"] = "api-json"
     elif framework and forms <= 1:
         profile["kind"] = "spa"
+    elif forms >= 10:
+        profile["kind"] = "heavy-site"
     elif forms >= 3:
         profile["kind"] = "forms-heavy"
     elif profile["waf"]:

--- a/sqldetector_qwen.py
+++ b/sqldetector_qwen.py
@@ -20,7 +20,7 @@ def main(argv=None):
     parser.add_argument("--trace-dir", type=str, help="Directory to store trace logs")
     parser.add_argument(
         "--preset",
-        choices=["fast","stealth","api","spa","forms","crawler","budget-ci"],
+        choices=["fast","stealth","api","spa","forms","crawler","budget-ci","turbo"],
         help="Use built-in preset",
     )
     parser.add_argument("--auto", action="store_true", help="Enable AutoPilot mode")

--- a/tests/test_selector_signals.py
+++ b/tests/test_selector_signals.py
@@ -33,3 +33,11 @@ def test_forms_classification():
     profile = classify_target("http://example", client, {"cores": 4, "ram_gb": 8})
     assert profile["kind"] == "forms-heavy"
     assert policy.choose_preset(profile) == "forms"
+
+
+def test_heavy_site_classification():
+    body = "<html>" + "<form></form>" * 10 + "</html>"
+    client = DummyClient({"Content-Type": "text/html"}, body)
+    profile = classify_target("http://example", client, {"cores": 4, "ram_gb": 8})
+    assert profile["kind"] == "heavy-site"
+    assert policy.choose_preset(profile) == "turbo"

--- a/tests/test_turbo_preset.py
+++ b/tests/test_turbo_preset.py
@@ -1,0 +1,7 @@
+from sqldetector.presets import load_preset
+
+
+def test_turbo_preset_values():
+    preset = load_preset("turbo")["sqldetector"]
+    assert preset["max_connections"] >= 100
+    assert preset["hedge_enabled"] is True


### PR DESCRIPTION
## Summary
- add turbo preset with aggressive defaults for high-spec runs
- map heavy sites to turbo via AutoPilot and CLI preset list
- document turbo preset and cover with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8bdccc33083259b6f5a12a009c112