### PR TITLE
feat: optional perf extras and dynamic encodings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ venv\Scripts\activate
 # Unix
 source venv/bin/activate
 pip install -e .
+
+# opt‑in extras
+pip install -e .[perf]     # http/2, compression, Bloom filters
+pip install -e .[waf]      # cloudscraper fallback
+pip install -e .[metrics]  # Prometheus /metrics endpoint
+pip install -e .[headless] # Playwright one‑off fetches
 ```
 
 `requirements.txt` lists optional legacy extras; the canonical dependency list lives in `pyproject.toml`.
-
-Optional performance extras:
-
-```bash
-pip install "httpx[http2,brotli,zstd]" truststore
-```
 
 
 > **Note:** The project targets Python 3.9+. On Python versions prior to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,25 @@ tls = [
     "truststore; python_version >= '3.10'",
 ]
 
+perf = [
+    "httpx[http2,brotli]",
+    "zstandard",
+    "truststore; python_version >= '3.10'",
+    "bitarray",
+    "xxhash",
+    "msgspec",
+    "boilerpy3",
+]
+waf = [
+    "cloudscraper",
+]
+metrics = [
+    "prometheus-client",
+]
+headless = [
+    "playwright",
+]
+
 [project.scripts]
 sqldetector = "sqldetector_qwen:main"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,16 +3,13 @@ beautifulsoup4
 llama-cpp-python==0.2.68
 httpx[http2,brotli,zstd]
 truststore; python_version>="3.10"
-# optional deps for fast preset
-# zstandard
-# xxhash
-# psutil
-# uvloop
-# pyahocorasick
-# re2
-# optional speed extras
-# aiodns
-# mmh3
-# psutil
-# orjson
-# simhash
+# optional perf extras
+zstandard
+bitarray
+xxhash
+msgspec
+boilerpy3
+# metrics
+prometheus-client
+# headless browser
+playwright

--- a/sqldetector/core/config.py
+++ b/sqldetector/core/config.py
@@ -49,7 +49,7 @@ class Settings:
     dns_warmup_batch: int = 8
     prewarm_connections: bool = False
     happy_eyeballs: bool = False
-    range_fetch_kb: int = 64
+    range_fetch_kb: int = 0
     http_cache_enabled: bool = False
     respect_robots: bool = True
     simhash_enabled: bool = False

--- a/sqldetector/core/http_async.py
+++ b/sqldetector/core/http_async.py
@@ -84,10 +84,23 @@ class HttpClient:
             verify = truststore.SSLContext()
         else:
             verify = certifi.where()
-        ae = "gzip" if self.settings.advanced.get("preset") == "stealth" else "br, gzip, zstd"
+        encodings = ["gzip"]
+        if self.settings.advanced.get("preset") != "stealth":
+            try:  # pragma: no cover - optional dependency
+                import brotli  # type: ignore
+
+                encodings.insert(0, "br")
+            except Exception:  # pragma: no cover - brotli not installed
+                pass
+            try:  # pragma: no cover - optional dependency
+                import zstandard  # type: ignore
+
+                encodings.append("zstd")
+            except Exception:  # pragma: no cover - zstandard not installed
+                pass
         headers = {
             "User-Agent": "sqldetector/1.0",
-            "Accept-Encoding": ae,
+            "Accept-Encoding": ", ".join(encodings),
         }
         transport = self.settings.transport
         if self.settings.http_cache_enabled:

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -2,6 +2,7 @@ import asyncio
 
 import httpx
 import pytest
+import importlib.util
 from typing import Any
 
 from sqldetector.core.config import Settings
@@ -115,3 +116,9 @@ async def test_client_configures_timeouts_and_limits(monkeypatch):
     assert limits.max_connections == 10
     assert limits.max_keepalive_connections == 5
     assert headers["User-Agent"] == "sqldetector/1.0"
+    encs = {e.strip() for e in headers["Accept-Encoding"].split(",")}
+    assert "gzip" in encs
+    if importlib.util.find_spec("brotli"):
+        assert "br" in encs
+    if importlib.util.find_spec("zstandard"):
+        assert "zstd" in encs


### PR DESCRIPTION
## Summary
- add extras groups for perf, waf, metrics and headless
- build HTTP Accept-Encoding dynamically and default range fetch off
- document new extras and ensure tests cover encoding choices

## Testing
- `pytest tests/test_http_client.py tests/test_range_fetch.py tests/test_http_cache.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8d46236d8832599e21eafc3b24381