### PR TITLE
feat: reorganize optional extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,13 @@ source venv/bin/activate
 pip install -e .
 
 # opt‑in extras
-pip install -e .[perf]     # http/2, compression, Bloom filters
-pip install -e .[waf]      # cloudscraper fallback
-pip install -e .[metrics]  # Prometheus /metrics endpoint
-pip install -e .[headless] # Playwright one‑off fetches
+pip install -e .[perf]      # HTTP/2 + compression
+pip install -e .[ssl]       # system trust store
+pip install -e .[metrics]   # Prometheus /metrics endpoint
+pip install -e .[fastdiff]  # faster diffing helpers
+pip install -e .[headless]  # Playwright one‑off fetches
+pip install -e .[bloom]     # persistent Bloom filters
+pip install -e .[waf]       # cloudscraper fallback
 ```
 
 `requirements.txt` lists optional legacy extras; the canonical dependency list lives in `pyproject.toml`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,12 @@ authors = [{name = "AutoGen"}]
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "httpx[http2,brotli,zstd]>=0.27",
+    "httpx[http2]>=0.27",
     "anyio>=4.0",
     "lxml>=5.0",
     "xxhash>=3.4",
-    "playwright>=1.45",
     "rich>=13.7",
     "tomli; python_version < '3.11'",
-    "zstandard",
     "psutil",
     "uvloop; platform_system != 'Windows'",
     "pyahocorasick",
@@ -34,6 +32,7 @@ dev = [
 test = [
     "pytest",
     "pytest-asyncio",
+    "xxhash",
 ]
 legacy = [
     "beautifulsoup4",
@@ -45,43 +44,28 @@ otel = [
     "opentelemetry-sdk>=1.26",
     "opentelemetry-exporter-otlp>=1.26"
 ]
-fast = [
-    "zstandard",
-    "xxhash",
-    "psutil",
-    "uvloop; platform_system != 'Windows'",
-    "pyahocorasick",
-    "re2",
-]
-speed = [
-    "aiodns",
-    "mmh3",
-    "psutil",
-    "orjson",
-    "simhash",
-]
-
-tls = [
-    "truststore; python_version >= '3.10'",
-]
-
 perf = [
     "httpx[http2,brotli]",
     "zstandard",
-    "truststore; python_version >= '3.10'",
-    "bitarray",
-    "xxhash",
-    "msgspec",
-    "boilerpy3",
 ]
-waf = [
-    "cloudscraper",
+ssl = [
+    "truststore; python_version >= '3.10'",
 ]
 metrics = [
     "prometheus-client",
 ]
+fastdiff = [
+    "xxhash>=3.4",
+    "msgspec",
+]
 headless = [
-    "playwright",
+    "playwright>=1.45",
+]
+bloom = [
+    "bitarray",
+]
+waf = [
+    "cloudscraper",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,17 @@
 cloudscraper
 beautifulsoup4
 llama-cpp-python==0.2.68
-httpx[http2,brotli,zstd]
-truststore; python_version>="3.10"
+httpx
 # optional perf extras
+httpx[http2,brotli]
 zstandard
+# optional SSL extras
+truststore; python_version>="3.10"
+# bloom filter
 bitarray
+# fast diffing
 xxhash
 msgspec
-boilerpy3
 # metrics
 prometheus-client
 # headless browser


### PR DESCRIPTION
## Summary
- refine optional dependency groups for perf, ssl, metrics, fastdiff, headless, bloom and waf
- document new extras in Installation section
- refresh requirements list to match extras

## Testing
- `ruff check sqldetector` *(fails: F401/E402)*
- `mypy .` *(fails: missing stubs, misc errors)*
- `pytest tests/test_http_cache.py -q`
- `pytest tests/test_http_client.py::test_retry_succeeds -q`
- `pytest tests/test_range_fetch.py::test_range_fetch_supported -q`
- `pytest tests/test_frontier_priority.py::test_frontier_priority_order -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8dae0e6fc8325aa1852f746065e32